### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -524,7 +524,7 @@ for each of these parameters is 5 seconds.
 The ``connect_timeout`` value controls the timeout for establishing a
 connection to the Telegram server(s).
 
-Changing the defaults of ``read_timeout`` & ``connet_timeout`` can be
+Changing the defaults of ``read_timeout`` & ``connect_timeout`` can be
 done by adjusting values ``request_kwargs`` section in ETM’s
 ``config.yaml``.
 


### PR DESCRIPTION
Fix a typo in the `README.rst` file where the "c" is missing in the word "connect".