### PR TITLE
Adjust skip_frames to 1 for precise duration

### DIFF
--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -143,7 +143,7 @@ def convert_tgs_to_gif(tgs_file: IO[bytes], gif_file: IO[bytes]):
         # heavy_strip(animation)
         # heavy_strip(animation)
         # animation.tgs_sanitize()
-        export_gif(animation, gif_file, skip_frames=1)  # , {"skip_frames": 5})
+        export_gif(animation, gif_file, skip_frames=1)
         return True
     except Exception:
         logging.exception("Error occurred while converting TGS to GIF.")

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -143,7 +143,7 @@ def convert_tgs_to_gif(tgs_file: IO[bytes], gif_file: IO[bytes]):
         # heavy_strip(animation)
         # heavy_strip(animation)
         # animation.tgs_sanitize()
-        export_gif(animation, gif_file)  # , {"skip_frames": 5})
+        export_gif(animation, gif_file, skip_frames=1)  # , {"skip_frames": 5})
         return True
     except Exception:
         logging.exception("Error occurred while converting TGS to GIF.")


### PR DESCRIPTION
For precise duration per frame of gif regarding to 
```
duration = 1000 / animation.frame_rate
```
in [gif.py#L36@tgs](https://gitlab.com/mattia.basaglia/tgs/blob/master/lib/tgs/exporters/gif.py#L36).

And we cat get acceptable gif result with patch for `tgs` [PR](https://gitlab.com/mattia.basaglia/tgs/merge_requests/3) except for tgs which has 3-D layers(I guess).

Test result:
### Without tgs patch

![ezgif-4-a33023e244dd](https://user-images.githubusercontent.com/1726386/66570709-b5dd8880-eba0-11e9-89b4-fc956f05ac30.gif)

### With tgs patch

![ezgif-4-f018ca88b50b](https://user-images.githubusercontent.com/1726386/66570722-bece5a00-eba0-11e9-864d-e0c9bf5412a3.gif)
