### PR TITLE
Fix exception when use /chat command in single linked group

### DIFF
--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -582,7 +582,8 @@ class ChatBindingManager(LocaleMixin):
                 try:
                     chat: ETMChat = ETMChat(
                         chat=self.get_chat_from_db(slave_channel_id, slave_chat_id) or
-                        channel.get_chat(slave_chat_id), db=self.db)
+                        channel.get_chat(slave_chat_id),
+                        db=self.db)
                     msg_text = self._('This group is linked to {0}'
                                       'Send a message to this group to deliver it to the chat.\n'
                                       'Do NOT reply to this system message.') \

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -582,7 +582,7 @@ class ChatBindingManager(LocaleMixin):
                 try:
                     chat: ETMChat = ETMChat(
                         chat=self.get_chat_from_db(slave_channel_id, slave_chat_id) or
-                        channel.get_chat(slave_chat_id))
+                        channel.get_chat(slave_chat_id), db=self.db)
                     msg_text = self._('This group is linked to {0}'
                                       'Send a message to this group to deliver it to the chat.\n'
                                       'Do NOT reply to this system message.') \


### PR DESCRIPTION
use `/chat` command in a group linked with only one slave chat throw `AssertionError` because
https://github.com/blueset/efb-telegram-master/blob/ff20fde6ad6c3acb40508e4b4be16e8afa26ebee/efb_telegram_master/chat.py#L26