### PR TITLE
Fix exception when migrate to super group

### DIFF
--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -812,9 +812,15 @@ class ChatBindingManager(LocaleMixin):
 
     def chat_migration(self, update: Update, context: CallbackContext):
         message = update.effective_message
-        from_id = ChatID(message.migrate_from_chat_id)
-        if from_id:
+        if message.migrate_from_chat_id is not None:
+            from_id = ChatID(message.migrate_from_chat_id)
             to_id = ChatID(message.chat.id)
+        elif message.migrate_to_chat_id is not None:
+            from_id = ChatID(message.chat.id)
+            to_id = ChatID(message.migrate_to_chat_id)
+        else:
+            # Per ptb filter specs, this part of code should not be reached.
+            return
         from_str = utils.chat_id_to_str(self.channel.channel_id, from_id)
         to_str = utils.chat_id_to_str(self.channel.channel_id, to_id)
         for i in self.db.get_chat_assoc(master_uid=from_str):

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -813,7 +813,8 @@ class ChatBindingManager(LocaleMixin):
     def chat_migration(self, update: Update, context: CallbackContext):
         message = update.effective_message
         from_id = ChatID(message.migrate_from_chat_id)
-        to_id = ChatID(message.migrate_to_chat_id)
+        if from_id:
+            to_id = ChatID(message.chat.id)
         from_str = utils.chat_id_to_str(self.channel.channel_id, from_id)
         to_str = utils.chat_id_to_str(self.channel.channel_id, to_id)
         for i in self.db.get_chat_assoc(master_uid=from_str):


### PR DESCRIPTION
telegram chat migrates to super group send two message.
each of them contains `migrate_from_chat_id` or `migrate_to_chat_id`