### PR TITLE
Fix link re exception

### DIFF
--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -225,7 +225,8 @@ class ChatBindingManager(LocaleMixin):
             try:
                 re_filter = re.compile(pattern, re.DOTALL | re.IGNORECASE) if pattern else None
             except re.error:
-                re_filter = None
+                pattern = re.escape(pattern)
+                re_filter = re.compile(pattern, re.DOTALL | re.IGNORECASE) if pattern else None
             if pattern:
                 self.logger.debug("Filter pattern: %s", pattern)
             chats: List[ETMChat] = []

--- a/efb_telegram_master/chat_binding.py
+++ b/efb_telegram_master/chat_binding.py
@@ -222,7 +222,10 @@ class ChatBindingManager(LocaleMixin):
 
         if chat_list is None or chat_list.length == 0:
             # Generate the full chat list first
-            re_filter = re.compile(pattern, re.DOTALL | re.IGNORECASE) if pattern else None
+            try:
+                re_filter = re.compile(pattern, re.DOTALL | re.IGNORECASE) if pattern else None
+            except re.error:
+                re_filter = None
             if pattern:
                 self.logger.debug("Filter pattern: %s", pattern)
             chats: List[ETMChat] = []


### PR DESCRIPTION
if use `/link hi(` to filter. etm will throw `re.error` exception.

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/efb_telegram_master/__init__.py", line 443, in error
    raise error
  File "/usr/lib/python3.7/site-packages/telegram/ext/dispatcher.py", line 372, in process_update
    handler.handle_update(update, self, check, context)
  File "/usr/lib/python3.7/site-packages/telegram/ext/handler.py", line 117, in handle_update
    return self.callback(update, context)
  File "/usr/lib/python3.7/site-packages/efb_telegram_master/chat_binding.py", line 188, in link_chat_show_list
    return self.link_chat_gen_list(message.from_user.id, pattern=" ".join(args))
  File "/usr/lib/python3.7/site-packages/efb_telegram_master/chat_binding.py", line 334, in link_chat_gen_list
    source_chats=chats)
  File "/usr/lib/python3.7/site-packages/efb_telegram_master/chat_binding.py", line 225, in slave_chats_pagination
    re_filter = re.compile(pattern, re.DOTALL | re.IGNORECASE) if pattern else None
  File "/usr/lib/python3.7/re.py", line 234, in compile
    return _compile(pattern, flags)
  File "/usr/lib/python3.7/re.py", line 286, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib/python3.7/sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib/python3.7/sre_parse.py", line 930, in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib/python3.7/sre_parse.py", line 426, in _parse_sub
    not nested and not items))
  File "/usr/lib/python3.7/sre_parse.py", line 819, in _parse
    source.tell() - start)
re.error: missing ), unterminated subpattern at position 2
```