### PR TITLE
Fix Animated Sticker / TGS Sticker Transparency Issues

### DIFF
--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -199,7 +199,7 @@ def export_gif(animation, fp, dpi=96, skip_frames=5):
         file.seek(0)
         frames.append(_png_gif_prepare(Image.open(file)))
 
-    duration = 1000 / animation.frame_rate * (1 + skip_frames) / 2
+    duration = 1000 / animation.frame_rate * (1 + skip_frames)  # why /2 before?
     frames[0].save(
         fp,
         format='GIF',

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -326,7 +326,7 @@ else:
         # get the gif file size
         new_file_size = os.path.getsize(gif_file.name)
         if new_file_size > 1024 * 1024:
-            scales = [600, 512, 480, 400, 360, 300, 256, 200, 150, 100]
+            scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
             scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
             if channel_id.startswith("blueset.wechat"):
                 for scale in scales:

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -223,7 +223,7 @@ def convert_tgs_to_gif(tgs_file: BinaryIO, gif_file: BinaryIO) -> bool:
         # heavy_strip(animation)
         # heavy_strip(animation)
         # animation.tgs_sanitize()
-        export_gif(animation, gif_file, skip_frames=5, dpi=48)
+        export_gif(animation, gif_file, skip_frames=5, dpi=48) # skip_frames = 5 means select one frame in every 5 frames
         return True
     except Exception:
         logging.exception("Error occurred while converting TGS to GIF.")

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -297,41 +297,62 @@ else:
         # 检查视频编码类型是否为VP9
         if metadata['streams'][0]['codec_name'] == 'vp9':
             stream = ffmpeg.input(file.name, vcodec='libvpx-vp9')
-        # generate a palettegen
-        palettegen_file = NamedTemporaryFile(suffix='.png')
-        (
-            stream
-            .output(palettegen_file.name, vf='palettegen=reserve_transparent=on')
-            .overwrite_output()
-            .run()
-        )
-        # generate a gif
-        palettegen = ffmpeg.input(palettegen_file.name)
-
-        stream = (
-            ffmpeg
-            .filter([stream, palettegen], 'paletteuse')
-        )
         if channel_id.startswith("blueset.wechat"):
             # Workaround: Compress GIF for slave channel `blueset.wechat`
             # TODO: Move this logic to `blueset.wechat` in the future
             if metadata.get('fps', 0) > 12:
                 stream = stream.filter("fps", 12, round='up')
-            stream_scale = stream.filter("scale", 600, -2, flags="lanczos")
-
-            stream_scale.output(gif_file.name).overwrite_output().run()
-            # get the gif file size
-            new_file_size = os.path.getsize(gif_file.name)
+            if metadata.get('width', 0) > 600:
+                stream = stream.filter("scale", 600, -2, flags="lanczos")
+        split = (
+            stream
+            .split()
+        )
+        stream_paletteuse = (
+            ffmpeg
+            .filter(
+                [
+                    split[0],
+                    split[1]
+                    .filter(
+                        filter_name='palettegen', 
+                        reserve_transparent='on',
+                    )
+                ],
+                filter_name='paletteuse',
+            )
+        )
+        stream_paletteuse.output(gif_file.name, fs=1400000).overwrite_output().run()
+        # get the gif file size
+        new_file_size = os.path.getsize(gif_file.name)
+        if new_file_size > 1024 * 1024:
             scales = [600, 512, 480, 400, 360, 300, 256, 200, 150, 100]
-            if new_file_size > 1024 * 1024:
+            scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
+            if channel_id.startswith("blueset.wechat"):
                 for scale in scales:
                     stream_scale = stream.filter("scale", scale, -2, flags="lanczos")
-                    stream_scale.output(gif_file.name).overwrite_output().run() 
+                    split = (
+                        stream_scale
+                        .split()
+                    )
+                    stream_paletteuse = (
+                        ffmpeg
+                        .filter(
+                            [
+                                split[0],
+                                split[1]
+                                .filter(
+                                    filter_name='palettegen', 
+                                    reserve_transparent='on',
+                                )
+                            ],
+                            filter_name='paletteuse',
+                        )
+                    )
+                    stream_paletteuse.output(gif_file.name, fs=1400000).overwrite_output().run() 
                     new_file_size = os.path.getsize(gif_file.name)
                     if new_file_size < 1024 * 1024:
                         break
-        else:
-            stream.output(gif_file.name).overwrite_output().run()
         file.close()
         gif_file.seek(0)
         return gif_file

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -160,6 +160,22 @@ def chat_id_str_to_id(s: EFBChannelChatIDStr) -> Tuple[ModuleID, ChatID, Optiona
         group_id = ChatID(ids[2])
     return channel_id, chat_uid, group_id
 
+def _png_gif_prepare(image):
+    """ Fork of lottie.exporters.gif.export_gif
+    Adapted from eltiempoes/python-lottie
+    https://github.com/eltiempoes/python-lottie/blob/a9f8be4858adb7eb0bc0e406a870b19c309c8a36/lib/lottie/exporters/gif.py#L10
+    License:
+        AGPL 3.0 (Python Lottie)
+    """
+    if image.mode not in ["RGBA", "RGBa"]:
+        image = image.convert("RGBA")
+    alpha = image.getchannel("A")
+    image = image.convert(image.mode[:-1]) \
+            .convert('P', palette=Image.ADAPTIVE, colors=255) # changed
+    mask = Image.eval(alpha, lambda a: 255 if a <= 128 else 0)
+    image.paste(255, mask=mask)
+    image.info['transparency'] = 255 # added
+    return image
 
 def export_gif(animation, fp, dpi=96, skip_frames=5):
     """ Fork of lottie.exporters.gif.export_gif
@@ -172,7 +188,7 @@ def export_gif(animation, fp, dpi=96, skip_frames=5):
     # Import only upon calling the method due to added binary dependencies
     # (libcairo)
     from lottie.exporters.cairo import export_png
-    from lottie.exporters.gif import _png_gif_prepare
+    # from lottie.exporters.gif import _png_gif_prepare # The code here have some problem, so I copy the function abo ve
 
     start = int(animation.in_point)
     end = int(animation.out_point)

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -322,7 +322,7 @@ else:
                 filter_name='paletteuse',
             )
         )
-        stream_paletteuse.output(gif_file.name, fs=1400000).overwrite_output().run()
+        stream_paletteuse.output(gif_file.name).overwrite_output().run()
         # get the gif file size
         new_file_size = os.path.getsize(gif_file.name)
         if new_file_size > 1024 * 1024:

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -294,6 +294,9 @@ else:
         file.seek(0)
         metadata = ffmpeg.probe(file.name)
         stream = ffmpeg.input(file.name)
+        # 检查视频编码类型是否为VP9
+        if metadata['streams'][0]['codec_name'] == 'vp9':
+            stream = ffmpeg.input(file.name, vcodec='libvpx')
         if channel_id.startswith("blueset.wechat"):
             # Workaround: Compress GIF for slave channel `blueset.wechat`
             # TODO: Move this logic to `blueset.wechat` in the future


### PR DESCRIPTION
During the process of investigating the GIF size limits, I also discovered that even if a sticker has transparency, this transparency is lost when the sticker is sent to WeChat:
![image](https://github.com/ehForwarderBot/efb-telegram-master/assets/44089074/2d519826-d2f8-4811-a744-b984367491e8)


To address this transparency issue, I found that decoding the WEBM files from Telegram correctly and using palettegen with the reserve_transparent flag, then encoding to GIF can retain transparency in a way that WeChat recognizes.

![image](https://github.com/ehForwarderBot/efb-telegram-master/assets/44089074/6c499e71-dfa0-46a8-82ee-242259cdcf82)

This pull request also tried resolves the transparency loss issue when sending tgs stickers from Telegram to WeChat via EFB, but there might still be an issue with the first frame of some TGS stickers having a black background.

---

在研究 GIF 大小限制的过程中, 我还发现即使原始贴图有透明背景, 发送到微信后也会丢失透明度, 变成不透明的黑色背景:
![image](https://github.com/ehForwarderBot/efb-telegram-master/assets/44089074/f0ed31eb-3d0e-4fa2-abe3-be5f25640f7f)

为了解决这个透明度丢失的问题, 我发现正确解码 Telegram 的 WEBM 文件, 并在生成调色板时使用 reserve_transparent 标志, 然后编码成 GIF, 就能以微信可识别的方式保留透明背景。

![image](https://github.com/ehForwarderBot/efb-telegram-master/assets/44089074/6c499e71-dfa0-46a8-82ee-242259cdcf82)
该 Pull Request 还尝试解决了从 Telegram 通过 EFB 发送 tgs 格式的贴图到微信时透明度丢失的问题，但某些 TGS 贴图的第一帧可能仍然会有黑色背景。