### PR TITLE
fix: only send new message if original message is a voice

### DIFF
--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -746,10 +746,13 @@ class SlaveMessageProcessor(LocaleMixin):
                         if str(tg_dest) == old_msg_id[0]:
                             target_msg_id = target_msg_id or old_msg_id[1]
                     else:
-                        assert msg.file is not None and msg.path is not None
-                        file = self.process_file_obj(msg.file, msg.path)
-                        return self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAudio(file, filename=msg.filename), reply_markup=reply_markup,
-                                                                prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
+                        assert msg.file is not None
+                        with tempfile.NamedTemporaryFile() as f:
+                            pydub.AudioSegment.from_file(msg.file).export(f, format="ogg", codec="libopus",
+                                                                        parameters=['-vbr', 'on'])
+                            file = self.process_file_obj(f, f.name)
+                            return self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAudio(file), reply_markup=reply_markup,
+                                                                    prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
                 else:
                     return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
                                                          reply_markup=reply_markup, prefix=msg_template,

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -17,7 +17,7 @@ import telegram.constants
 import telegram.error
 import telegram.ext
 from PIL import Image
-from telegram import InputFile, ChatAction, InputMediaPhoto, InputMediaDocument, InputMediaVideo, InputMediaAnimation, \
+from telegram import InputFile, ChatAction, InputMediaAudio, InputMediaPhoto, InputMediaDocument, InputMediaVideo, InputMediaAnimation, \
     InlineKeyboardMarkup, InlineKeyboardButton, ReplyMarkup, TelegramError, InputMedia
 
 from ehforwarderbot import Message, Status, coordinator
@@ -739,10 +739,17 @@ class SlaveMessageProcessor(LocaleMixin):
 
             if old_msg_id:
                 if edit_media:
-                    # Cannot edit voice message content, send a new one instead
-                    msg_template += " " + self._("[Edited]")
-                    if str(tg_dest) == old_msg_id[0]:
-                        target_msg_id = target_msg_id or old_msg_id[1]
+                    original_message = self.channel.get_message_by_id(msg.chat, old_msg_id[1])
+                    if original_message and original_message.type == MsgType.Voice:
+                        # Cannot edit voice message content, send a new one instead
+                        msg_template += " " + self._("[Edited]")
+                        if str(tg_dest) == old_msg_id[0]:
+                            target_msg_id = target_msg_id or old_msg_id[1]
+                    else:
+                        assert msg.file is not None and msg.path is not None
+                        file = self.process_file_obj(msg.file, msg.path)
+                        return self.bot.edit_message_media(chat_id=old_msg_id[0], message_id=old_msg_id[1], media=InputMediaAudio(file, filename=msg.filename), reply_markup=reply_markup,
+                                                                prefix=msg_template, suffix=reactions, caption=text, parse_mode="HTML")
                 else:
                     return self.bot.edit_message_caption(chat_id=old_msg_id[0], message_id=old_msg_id[1],
                                                          reply_markup=reply_markup, prefix=msg_template,


### PR DESCRIPTION
在使用 voice 编辑一个消息的时候，之前的逻辑会直接发送新消息，但是如果被编辑的消息原来是一个非 voice 的消息时，实际是可以编辑成功的