### PR TITLE
feat: save vendor_specific persistent

### DIFF
--- a/efb_telegram_master/db.py
+++ b/efb_telegram_master/db.py
@@ -139,6 +139,8 @@ class MsgLog(BaseModel):
                 msg.attributes = misc_data['attributes']
             if 'commands' in misc_data:
                 msg.commands = misc_data['commands']
+            if 'vendor_specific' in misc_data:
+                msg.vendor_specific = misc_data['vendor_specific']
             if 'substitutions' in misc_data:
                 subs = Substitutions({})
                 for sk, sv in misc_data['substitutions'].items():
@@ -318,6 +320,8 @@ class DatabaseManager:
             data['attributes'] = message.attributes
         if message.commands:
             data['commands'] = message.commands
+        if message.vendor_specific:
+            data['vendor_specific'] = message.vendor_specific
         if message.substitutions:
             data['substitutions'] = {
                 k: chat_id_to_str(chat=v)


### PR DESCRIPTION
序列化和反序列化 message 的 vendor_specific 字段，目前用于存储 comwechat slave 原始的微信 xml 数据以供后续使用