### PR TITLE
fix: update chat member info properly

### DIFF
--- a/efb_telegram_master/chat_object_cache.py
+++ b/efb_telegram_master/chat_object_cache.py
@@ -192,7 +192,12 @@ class ChatObjectCacheManager:
     def get_or_enrol_member(cached: ETMChatType, member: ChatMember) -> ETMChatMember:
         # TODO: Add test case for this
         try:
-            return cached.get_member(member.uid)
+            m = cached.get_member(member.uid)
+            m.name = member.name
+            m.alias = member.alias
+            m.description = member.description
+            m.vendor_specific = member.vendor_specific
+            return m
         except KeyError:
             cached_member: ETMChatMember
             if isinstance(member, SystemChatMember):


### PR DESCRIPTION
当 member 进入 cache 之后，更新 name, alias, description 无法正确反应。由 2768071 引入