### PR TITLE
fix: handle file:// URIs in media paths

### DIFF
--- a/efb_telegram_master/bot_manager.py
+++ b/efb_telegram_master/bot_manager.py
@@ -13,6 +13,7 @@ from retrying import retry
 from telegram import Update, InputFile, User, File
 from telegram.ext import CallbackContext, Filters, MessageHandler, Updater, Dispatcher
 
+from . import utils
 from .locale_handler import LocaleHandler
 from .locale_mixin import LocaleMixin
 
@@ -581,7 +582,8 @@ class TelegramBotManager(LocaleMixin):
     def _detect_empty_file(self, file, chat, caption, prefix, suffix):
         empty = True
         if isinstance(file, str):
-            empty = os.stat(file).st_size == 0
+            local_path = utils.coerce_local_path(file)
+            empty = os.stat(local_path).st_size == 0
         elif hasattr(file, "seekable"):
             if file.seekable():
                 file.seek(0, 2)

--- a/efb_telegram_master/slave_message.py
+++ b/efb_telegram_master/slave_message.py
@@ -543,7 +543,7 @@ class SlaveMessageProcessor(LocaleMixin):
             else:
                 assert msg.file and msg.path
                 file = self.process_file_obj(msg.file, msg.path)
-                file_: Union[IO[bytes], bytes] = open(file, 'rb') if isinstance(file, str) else file
+                file_: Union[IO[bytes], bytes] = open(utils.coerce_local_path(file), 'rb') if isinstance(file, str) else file
                 return self.bot.send_animation(tg_dest, InputFile(file_, filename=msg.filename),
                                                prefix=msg_template, suffix=reactions,
                                                caption=text, parse_mode="HTML",

--- a/efb_telegram_master/utils.py
+++ b/efb_telegram_master/utils.py
@@ -6,6 +6,8 @@ import logging
 import os
 import subprocess
 import sys
+import urllib.parse
+import urllib.request
 from io import BytesIO
 from shutil import copyfileobj
 from tempfile import NamedTemporaryFile
@@ -77,6 +79,25 @@ def b64de(s: str) -> str:
     if missing_padding:
         s += '=' * (4 - missing_padding)
     return base64.urlsafe_b64decode(s).decode()
+
+
+def coerce_local_path(path_or_uri: str) -> str:
+    parts = urllib.parse.urlsplit(path_or_uri)
+    if parts.scheme != "file":
+        return path_or_uri
+
+    path = urllib.request.url2pathname(urllib.parse.unquote(parts.path))
+    if os.name == "nt":
+        if parts.netloc:
+            unc_path = path.replace("/", "\\")
+            return f"\\\\{parts.netloc}{unc_path}"
+        if len(path) >= 3 and path[0] == "/" and path[2] == ":":
+            path = path[1:]
+        return path
+
+    if parts.netloc:
+        return f"//{parts.netloc}{path}"
+    return path
 
 
 def message_id_to_str(chat_id: Optional[TelegramChatID] = None,


### PR DESCRIPTION
[local_tdlib_api=True](https://github.com/ehForwarderBot/efb-telegram-master/blob/0850aeb294260c3cc14d382991837f99e12fae8c/efb_telegram_master/slave_message.py#L1018-L1019
) 会把 本地文件 转为 `file:///xxxx` 字符串，[os.stat](https://github.com/ehForwarderBot/efb-telegram-master/blob/0850aeb294260c3cc14d382991837f99e12fae8c/efb_telegram_master/bot_manager.py#L584) 会报 not_found

fix https://github.com/ehForwarderBot/efb-telegram-master/issues/127